### PR TITLE
Display all contentful homepage data

### DIFF
--- a/src/components/atoms/description.js
+++ b/src/components/atoms/description.js
@@ -1,0 +1,12 @@
+import React from "react"
+import PropTypes from "prop-types"
+
+const Description = ({text}) => (
+  <p>{text}</p>
+)
+
+Description.propTypes = {
+  text: PropTypes.string,
+}
+
+export default Description

--- a/src/components/atoms/title.js
+++ b/src/components/atoms/title.js
@@ -1,0 +1,12 @@
+import React from "react"
+import PropTypes from "prop-types"
+
+const Title = ({text}) => (
+  <h1>{text}</h1>
+)
+
+Title.propTypes = {
+  text: PropTypes.string,
+}
+
+export default Title

--- a/src/components/molecules/navigation.js
+++ b/src/components/molecules/navigation.js
@@ -22,7 +22,7 @@ export default function Navigation() {
   return (
     <nav>
       {navLinks.map(link => (
-        <li>
+        <li key={link.name}>
           <Styled.a
             as={Link}
             to={link.url}

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -1,13 +1,45 @@
-import React from "react"
+import React, { Component } from "react"
+import { graphql } from "gatsby"
 import Layout from "../components/templates/layout"
+import Title from "../components/atoms/title"
+import Description from "../components/atoms/description"
 
-const IndexPage = () => {
-  return (
-    <>
-      <Layout />
-      Home
-    </>
-  )
+class IndexPage extends Component {
+  render() {
+    const homepageData = this.props.data.allContentfulHomepageData.edges
+
+    return (
+      <>
+        <Layout />
+        {homepageData.map(data => {
+          const title = data.node.title
+          const description = data.node.simpleDescription.simpleDescription
+
+          return (
+            <div key={data.node.id}>
+              <Title text={title} />
+              <Description text={description} />
+            </div>
+          )
+        })}
+      </>
+    )
+  }
 }
 
 export default IndexPage
+
+export const homePageQuery = graphql`
+  query homePageQuery {
+    allContentfulHomepageData {
+      edges {
+        node {
+          id
+          title
+          simpleDescription {
+            simpleDescription
+          }
+        }
+      }
+    }
+  }`


### PR DESCRIPTION
Fetch and display all contentful homepage data (Currently one published  placeholder record)

![Screen Shot 2020-09-09 at 5 00 18 PM](https://user-images.githubusercontent.com/40510669/92659426-f4eaf100-f2bd-11ea-9a12-431c78ae5392.png)

Fixes #3 

Pair: @zopa 